### PR TITLE
fix: add missing closing brace in MARKTLOKATION test scenario

### DIFF
--- a/testszenarios/LIEFERENDE_NB_TESTSZENARIO19_55004/LESEN_MARKTLOKATION_BASIS
+++ b/testszenarios/LIEFERENDE_NB_TESTSZENARIO19_55004/LESEN_MARKTLOKATION_BASIS
@@ -5,6 +5,7 @@
         "boTyp": "MARKTLOKATION",
         "versionStruktur": "1",
         "netzbetreiberCodeNr": "9900321000005"
+      }
     ]
   }
 }


### PR DESCRIPTION
The current json is malformed which ends up with error in Apache Nifi.